### PR TITLE
.envrc added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules
 
 
 # local env files
+.envrc
 .env.local
 .env.*.local
 


### PR DESCRIPTION
Once .envrc is created, it will show as a new file to be committed. Adding this to .gitignore will keep personal environment variables from entering the repo.