### PR TITLE
build(eslint): added ignore rule for no-unused-vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,11 +14,13 @@ module.exports = {
   rules: {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/no-inferrable-types': 'off',
+    '@typescript-eslint/no-unused-vars': [2, {'args': 'after-used', 'argsIgnorePattern': '^_'}],
     'comma-dangle': ['error', 'always-multiline'],
     'indent': ['error', 2],
     'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
     'no-multiple-empty-lines': ['error', { 'max': 2 }],
+    'no-unused-vars': [2, {'args': 'after-used', 'argsIgnorePattern': '^_'}],
     'no-useless-constructor': 'off',
     'quotes': ['error', 'single'],
     'semi': ['error', 'always'],

--- a/src/vue/components/pages/services/ServiceForm.vue
+++ b/src/vue/components/pages/services/ServiceForm.vue
@@ -73,7 +73,6 @@ export default defineComponent({
       try {
         return await load();
       } catch (error) {
-        console.log({ error });
         return error;
       }
     });


### PR DESCRIPTION
Variables prefixed with _ should be left alone