### PR TITLE
PostCSS config to purge tailwind in production only

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,11 +1,23 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const tailwindcss = require('tailwindcss');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const autoprefixer = require('autoprefixer');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const tailwindcss = require('tailwindcss');
+const postcssPurgecss = require('@fullhuman/postcss-purgecss');
+
+const IN_PRODUCTION = process.env.NODE_ENV === 'production';
 
 module.exports = {
   plugins: [
     tailwindcss,
     autoprefixer,
+    IN_PRODUCTION && postcssPurgecss({
+      content: [ './public/**/*.html', './src/**/*.vue' ],
+      defaultExtractor: (content) => {
+        const contentWithoutStyleBlocks = content.replace(/<style[^]+?<\/style>/gi, '');
+        return contentWithoutStyleBlocks.match(/[A-Za-z0-9-_/:]*[A-Za-z0-9-_/]+/g) || [];
+      },
+      whitelistPatterns: [ /-(leave|enter|appear)(|-(to|from|active))$/, /^(?!cursor-move).+-move$/, /^router-link(|-exact)-active$/ ],
+    }),
   ],
 };


### PR DESCRIPTION
When the app gets built, PostCSS will purge all unused TailwindCSS classes, making the final bundle way lighter.

<img width="1215" alt="Screen Shot 2020-10-01 at 14 51 18" src="https://user-images.githubusercontent.com/42949739/94865694-aaafe800-0403-11eb-9199-0b3e1f2a7440.png">

Closes #125.