### PR TITLE
fix: Support arbitrary files

### DIFF
--- a/src/files/images.ts
+++ b/src/files/images.ts
@@ -28,7 +28,7 @@ export const readImage = async (file: File) => {
     preview = await getText(file);
   }
 
-  const date = (tags?.MetadataDate?.description || tags?.DateTimeOriginal?.description || null) as string | undefined;
+  const date = tags?.MetadataDate?.description || tags?.DateTimeOriginal?.description || null;
 
   return {
     date,

--- a/src/files/metadata.ts
+++ b/src/files/metadata.ts
@@ -23,15 +23,15 @@ export interface FileMetadata {
   size: number;
   storage: FileStorage;
   public: boolean;
-  date?: string;
-  tags?: FileTags;
+  date: string | null;
+  tags: FileTags;
 }
 
-export type FileTags = ExifTags;
+export type FileTags = ExifTags | null;
 
 export interface FileInfo {
-  date: string;
-  content: string;
+  date: string | null;
+  preview: string;
   tags: FileTags;
 }
 
@@ -63,8 +63,17 @@ export const isSupportedMime = (mime: string): mime is keyof typeof MIME_OPTIONS
   return mime in MIME_OPTIONS;
 };
 
+export const readUnsupportedFile = async (file: File): Promise<FileInfo> => {
+  const lastModified = new Date(file.lastModified);
 
-export const readFile = (file: File) => {
+  return {
+    date: lastModified.toISOString(),
+    preview: '',
+    tags: null,
+  };
+};
+
+export const readFile = (file: File): Promise<FileInfo> => {
   const mime = file.type;
 
   if (isSupportedMime(mime)) {
@@ -73,5 +82,5 @@ export const readFile = (file: File) => {
     return options.reader(file);
   }
 
-  throw new Error(`Unrecognised file format: '${file.type}'`);
+  return Promise.resolve(readUnsupportedFile(file));
 };

--- a/src/models/Fragment.ts
+++ b/src/models/Fragment.ts
@@ -1,5 +1,5 @@
 import { modelize, ModelProps } from '~/src/models/Model';
-import { FileMetadata, FileStorage, readFile } from '~/src/files/metadata';
+import { FileMetadata, FileStorage, readFile, isSupportedMime } from '~/src/files/metadata';
 
 
 export interface FragmentProps extends ModelProps {
@@ -20,7 +20,7 @@ export class Fragment extends modelize<FragmentProps>(namespace, fields) {
   constructor(props: FragmentProps) {
     super(props);
     this.concept = props.concept;
-    this.meta = props.meta ?? { filename: '', mime: '', size: 0, storage: FileStorage.PREVIEW, public: false };
+    this.meta = props.meta ?? { filename: '', mime: '', size: 0, storage: FileStorage.PREVIEW, public: false, date: null, tags: null };
     this.notes = props.notes ?? '';
   }
 
@@ -48,6 +48,10 @@ export class Fragment extends modelize<FragmentProps>(namespace, fields) {
     fragments.pop();
 
     return fragments.join('.');
+  }
+
+  get hasPreview() {
+    return isSupportedMime(this.meta.mime);
   }
 
   get url() {

--- a/src/vue/pages/Concepts/_uuid.vue
+++ b/src/vue/pages/Concepts/_uuid.vue
@@ -100,7 +100,7 @@ export default defineComponent({
     });
 
     const preview = computed(() => {
-      return fragments.value.find((fragment) => fragment.meta.storage === FileStorage.PREVIEW);
+      return fragments.value.find((fragment) => fragment.hasPreview && fragment.meta.storage === FileStorage.PREVIEW);
     });
 
     const removeFragment = (fragment: Fragment) => {
@@ -141,7 +141,7 @@ export default defineComponent({
       await fragment.setFile(value);
 
 
-      fragments.value.unshift(fragment);
+      fragments.value.push(fragment);
       readMetadata(fragment);
     };
 

--- a/tests/unit/models/Fragment.test.ts
+++ b/tests/unit/models/Fragment.test.ts
@@ -1,11 +1,11 @@
-
 import * as fs from 'fs';
 import * as path from 'path';
 
 import sinon from 'sinon';
 
-import '~/tests/setup';
 import { Fragment } from '~/src/models/Fragment';
+import { MIME_OPTIONS } from '~/src/files/metadata';
+
 
 const getInstance = (props = {}) => {
   const fragment = new Fragment({
@@ -16,7 +16,7 @@ const getInstance = (props = {}) => {
   return fragment;
 };
 
-const pixel = fs.readFileSync(path.join(__dirname, '../../../fixtures/images/1pixel.jpeg'));
+const pixel = fs.readFileSync(path.join(__dirname, '../../fixtures/images/1pixel.jpeg'));
 
 const getFile = () => {
   const blob = new Blob([pixel], { type: 'image/jpeg' });
@@ -25,17 +25,18 @@ const getFile = () => {
   return file;
 };
 
-describe('unit.app.models.Fragment', () => {
+describe('unit.models.Fragment', () => {
+
   afterEach(() => sinon.restore());
 
-  describe('.constructor', () => {
+  describe('constructor', () => {
     it('Creates a Fragment', () => {
       const fragment = getInstance();
       expect(fragment.constructor.name).toEqual('Fragment');
     });
   });
 
-  describe('.setFile', () => {
+  describe('setFile', () => {
     it('Stores the file', async () => {
       const fragment = getInstance();
       const file = getFile();
@@ -64,6 +65,31 @@ describe('unit.app.models.Fragment', () => {
       await fragment.setFile(file);
 
       expect(fragment.data).toEqual(expected);
+    });
+  });
+
+  describe('hasPreview', () => {
+
+    describe('Has preview with a supported mime', () => {
+      Object.keys(MIME_OPTIONS).forEach((mime) => {
+        it(`Mime: '${mime}'`, () => {
+          const fragment = new Fragment({ concept: 'abc' });
+          fragment.meta.mime = mime;
+
+          expect(fragment.hasPreview).toEqual(true);
+        });
+      });
+    });
+
+    describe('No preview with unsupported mime', () => {
+      ['application/json', 'application/xml', 'random'].forEach((mime) => {
+        it(`Mime: '${mime}'`, () => {
+          const fragment = new Fragment({ concept: 'abc' });
+          fragment.meta.mime = mime;
+
+          expect(fragment.hasPreview).toEqual(false);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
Files not matching the supported mimes will be processed with a default `readUnsupportedFile` which will yield some basic information. Additionally, fragments will not try to create a preview if the mime is
not supported.

Closes #176