### PR TITLE
Setting purge as false since tailwind is purged from PostCSS

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,7 @@ module.exports = {
     removeDeprecatedGapUtilities: true,
     purgeLayersByDefault: true,
   },
-  purge: [],
+  purge: false,
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Since Tailwind is getting purged from PostCSS this should be explicit on `tailwind.config.js` setting `purge` as false instead of an empty array.
Closes #135 