### PR TITLE
feat: Clickable tooltips and text field help

### DIFF
--- a/src/assets/scss/components/_pho_field.scss
+++ b/src/assets/scss/components/_pho_field.scss
@@ -1,5 +1,13 @@
 .pho-field-wrapper {
   @apply mb-4;
+
+  .help {
+    right: 1px;
+    top: 0px;
+    cursor: pointer;
+    user-select: none;
+  }
+
 }
 
 .pho-field {

--- a/src/plugins/font-awesome.ts
+++ b/src/plugins/font-awesome.ts
@@ -9,6 +9,7 @@ import {
   faChevronDown,
   faCloudDownloadAlt,
   faCloudUploadAlt,
+  faInfoCircle,
   faLink,
   faTimes,
   faTrash,
@@ -18,6 +19,7 @@ library.add(faCheckSquare);
 library.add(faChevronDown);
 library.add(faCloudDownloadAlt);
 library.add(faCloudUploadAlt);
+library.add(faInfoCircle);
 library.add(faLink);
 library.add(faTimes);
 library.add(faTrash);

--- a/src/vue/components/pages/services/ServiceForm.vue
+++ b/src/vue/components/pages/services/ServiceForm.vue
@@ -8,8 +8,17 @@
       <Integration :service="service" selected />
       <div class="space-y-4">
         <div class="space-y-4">
-          <PhoTextField v-model="user.name" name="user.name" label="Photion Username" />
-          <PhoTextField v-model="user.password" name="user.password" label="Encryption Password" type="password" />
+          <PhoTextField
+            v-model="user.name"
+            name="user.name"
+            label="Photion Username"
+            help="Used by your integration" />
+          <PhoTextField
+            v-model="user.password"
+            name="user.password"
+            label="Encryption Password"
+            type="password"
+            help="Used to decrypt your local secrets from the browser" />
         </div>
         <div>
           <slot />

--- a/src/vue/components/ui/PhoTooltip.vue
+++ b/src/vue/components/ui/PhoTooltip.vue
@@ -1,18 +1,24 @@
 <template>
-  <div class="wrapper relative" @mouseenter="on.enter" @mouseleave="on.leave">
-    <div class="inline-block">
-      <slot ></slot>
+  <div
+    class="wrapper relative"
+    @mouseenter="on.enter"
+    @mouseleave="on.leave"
+    @click="on.click"
+    :id="id.unique"
+    :cy="id.family">
+    <div class="inline-block w-full">
+      <slot></slot>
     </div>
     <transition name="slide">
       <div
         v-if="show"
-        :id="id.unique"
-        :cy="id.family"
+        :id="`${id.unique}:tooltip`"
+        :ci="`${id.family}:tooltip`"
         :style="styles.tooltip.value"
         class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1"
         :class="position">
         <slot name="content">
-          <span v-if="text" class="text-xs tracking-wide">{{ text }}</span>
+          <div v-if="text" class="text-xs tracking-wide">{{ text }}</div>
         </slot>
       </div>
     </transition>
@@ -66,13 +72,23 @@ export default defineComponent({
       tooltip: computed(() => getTooltipStyles(props.delayIn, props.delayOut)),
     };
 
+    let timeout: NodeJS.Timeout;
+
+    const trigger = (state: boolean, delay = 0) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        show.value = state;
+      }, delay);
+    };
+
     return {
       id: useId('tooltip', props),
       styles,
       show,
       on: {
-        enter: () => (show.value = true),
-        leave: () => (show.value = false),
+        click: () => trigger(!show.value),
+        enter: () => trigger(true, props.delayIn),
+        leave: () => trigger(false, props.delayOut),
       },
     };
   },
@@ -105,12 +121,9 @@ $offset-active: 20%;
   }
 }
 
-.wrapper {
-  width: fit-content;
-}
-
 .tooltip {
   max-width: 12rem;
+  width: max-content;
 
   &::after {
     content: "";
@@ -186,12 +199,10 @@ $offset-active: 20%;
 
 .slide-enter-active {
   transition-duration: 150ms;
-  transition-delay: var(--transition-delay-in);
 }
 
 .slide-leave-active {
   transition-duration: 150ms;
-  transition-delay: var(--transition--delay-out);
 }
 
 .slide-enter-from {

--- a/src/vue/components/ui/forms/PhoTextField.vue
+++ b/src/vue/components/ui/forms/PhoTextField.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="pho-field-wrapper">
+  <div class="pho-field-wrapper w-full relative">
     <label v-if="label" :for="id.unique" class="pho-label">
       {{ label }}
     </label>
@@ -14,20 +14,35 @@
       :disabled="disabled"
       v-bind="$attrs"
       @input="onInput" />
+    <div v-if="help" class="help absolute">
+      <PhoTooltip :text="help" :name="name" :uuid="uuid" position="top"><FontAwesomeIcon icon="info-circle" /></PhoTooltip>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent } from 'vue';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { useId, componentProps } from '~/src/vue/components/shared';
 import { getFormProps } from '~/src/vue/components/ui/forms/forms';
 
+import PhoTooltip from '~/src/vue/components/ui/PhoTooltip.vue';
+
 export default defineComponent({
+
+  components: {
+    FontAwesomeIcon,
+    PhoTooltip,
+  },
 
   props: {
     ...componentProps,
     ...getFormProps(String),
+    help: {
+      type: String,
+      default: () => '',
+    },
     type: {
       type: String,
       default: 'text',

--- a/tests/unit/vue/components/ui/PhoTooltip.test.ts
+++ b/tests/unit/vue/components/ui/PhoTooltip.test.ts
@@ -5,7 +5,7 @@ import PhoTooltip from '~/src/vue/components/ui/PhoTooltip.vue';
 const getComponent = <T, Y>(props: T, slots?: Y) => {
   return mount(PhoTooltip, {
     props: {
-      name: 'pho-button-comp',
+      name: 'pho-tooltip-comp',
       uuid: 'my-uuid',
       ...props,
     },
@@ -20,24 +20,19 @@ describe('unit.vue.components.ui.PhoTooltip', () => {
 
   const positions = ['top', 'right', 'bottom', 'left'];
 
+  beforeEach(() => jest.useFakeTimers());
+
   it('Mounts', () => {
     const wrapper = getComponent({});
     expect(wrapper.element).toMatchSnapshot();
   });
 
   describe('On mouse enter', () => {
-    it('Sets the attributes when it is shown', async () => {
-      const wrapper = getComponent({});
-      await wrapper.trigger('mouseenter');
-      const attributes = wrapper.get('[cy]').attributes();
-
-      expect(attributes).toMatchSnapshot();
-    });
-
     positions.forEach((position) => {
       it(`Renders the text on '${position}'`, async () => {
         const wrapper = getComponent({ text: 'Some Tooltip Text', position });
         await wrapper.trigger('mouseenter');
+        await jest.runOnlyPendingTimers();
         expect(wrapper.element).toMatchSnapshot();
       });
     });
@@ -47,18 +42,62 @@ describe('unit.vue.components.ui.PhoTooltip', () => {
         const content = '<div>Tooltip with <strong>strong</strong> html content</div>';
         const wrapper = getComponent({}, { content, position });
         await wrapper.trigger('mouseenter');
+        await jest.runOnlyPendingTimers();
         expect(wrapper.element).toMatchSnapshot();
       });
     });
+
+    it('Sets the attributes when it is shown', async () => {
+      const wrapper = getComponent({});
+      await wrapper.trigger('mouseenter');
+      await jest.runAllTimers();
+      const attributes = wrapper.get('[cy]').attributes();
+
+      expect(attributes).toMatchSnapshot();
+    });
+
   });
 
   describe('On mouse leave', () => {
     it('Hides the tooltip', async () => {
       const wrapper = getComponent({ text: 'Some Tooltip Text' });
       await wrapper.trigger('mouseenter');
+      await jest.runAllTimers();
       await wrapper.trigger('mouseleave');
+      await jest.runAllTimers();
       expect(wrapper.element).toMatchSnapshot();
     });
+  });
+
+  describe('On mouse click', () => {
+    describe('With one click', () => {
+      it('Shows the tooltip', async () => {
+        const wrapper = getComponent({ text: 'Some Tooltip Text' });
+        await wrapper.trigger('click');
+        await jest.runAllTimers();
+        expect(wrapper.element).toMatchSnapshot();
+      });
+
+      it('Overrides mouseenter', async () => {
+        const wrapper = getComponent({ text: 'Some Tooltip Text' });
+        await wrapper.trigger('mouseenter');
+        await wrapper.trigger('click');
+        await jest.runAllTimers();
+        expect(wrapper.element).toMatchSnapshot();
+      });
+    });
+
+    describe('With two clicks', () => {
+      it('Hides the tooltip', async () => {
+        const wrapper = getComponent({ text: 'Some Tooltip Text' });
+        await wrapper.trigger('click');
+        await jest.runAllTimers();
+        await wrapper.trigger('click');
+        await jest.runAllTimers();
+        expect(wrapper.element).toMatchSnapshot();
+      });
+    });
+
   });
 
 });

--- a/tests/unit/vue/components/ui/__snapshots__/PhoTooltip.test.ts.snap
+++ b/tests/unit/vue/components/ui/__snapshots__/PhoTooltip.test.ts.snap
@@ -3,9 +3,100 @@
 exports[`unit.vue.components.ui.PhoTooltip Mounts 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
+  >
+    
+    
+    Tooltip Trigger
+    
+    
+  </div>
+  <transition-stub>
+    <!--v-if-->
+  </transition-stub>
+</div>
+`;
+
+exports[`unit.vue.components.ui.PhoTooltip On mouse click With one click Overrides mouseenter 1`] = `
+<div
+  class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
+>
+  <div
+    class="inline-block w-full"
+  >
+    
+    
+    Tooltip Trigger
+    
+    
+  </div>
+  <transition-stub>
+    <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
+      class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
+      style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
+    >
+      
+      <div
+        class="text-xs tracking-wide"
+      >
+        Some Tooltip Text
+      </div>
+      
+    </div>
+  </transition-stub>
+</div>
+`;
+
+exports[`unit.vue.components.ui.PhoTooltip On mouse click With one click Shows the tooltip 1`] = `
+<div
+  class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
+>
+  <div
+    class="inline-block w-full"
+  >
+    
+    
+    Tooltip Trigger
+    
+    
+  </div>
+  <transition-stub>
+    <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
+      class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
+      style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
+    >
+      
+      <div
+        class="text-xs tracking-wide"
+      >
+        Some Tooltip Text
+      </div>
+      
+    </div>
+  </transition-stub>
+</div>
+`;
+
+exports[`unit.vue.components.ui.PhoTooltip On mouse click With two clicks Hides the tooltip 1`] = `
+<div
+  class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
+>
+  <div
+    class="inline-block w-full"
   >
     
     
@@ -22,9 +113,11 @@ exports[`unit.vue.components.ui.PhoTooltip Mounts 1`] = `
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content slot on 'bottom' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -34,9 +127,9 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
@@ -58,9 +151,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content slot on 'left' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -70,9 +165,9 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
@@ -94,9 +189,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content slot on 'right' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -106,9 +203,9 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
@@ -130,9 +227,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content slot on 'top' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -142,9 +241,9 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
@@ -166,9 +265,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the content sl
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'bottom' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -178,17 +279,17 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'b
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
-      <span
+      <div
         class="text-xs tracking-wide"
       >
         Some Tooltip Text
-      </span>
+      </div>
       
     </div>
   </transition-stub>
@@ -198,9 +299,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'b
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'left' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -210,17 +313,17 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'l
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 left"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
-      <span
+      <div
         class="text-xs tracking-wide"
       >
         Some Tooltip Text
-      </span>
+      </div>
       
     </div>
   </transition-stub>
@@ -230,9 +333,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'l
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'right' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -242,17 +347,17 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'r
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 right"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
-      <span
+      <div
         class="text-xs tracking-wide"
       >
         Some Tooltip Text
-      </span>
+      </div>
       
     </div>
   </transition-stub>
@@ -262,9 +367,11 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'r
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 'top' 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     
@@ -274,17 +381,17 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 't
   </div>
   <transition-stub>
     <div
+      ci="tooltip:pho-tooltip-comp:tooltip"
       class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 top"
-      cy="tooltip:pho-button-comp"
-      id="tooltip:pho-button-comp:my-uuid"
+      id="tooltip:pho-tooltip-comp:my-uuid:tooltip"
       style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
     >
       
-      <span
+      <div
         class="text-xs tracking-wide"
       >
         Some Tooltip Text
-      </span>
+      </div>
       
     </div>
   </transition-stub>
@@ -293,19 +400,20 @@ exports[`unit.vue.components.ui.PhoTooltip On mouse enter Renders the text on 't
 
 exports[`unit.vue.components.ui.PhoTooltip On mouse enter Sets the attributes when it is shown 1`] = `
 Object {
-  "class": "tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 bottom",
-  "cy": "tooltip:pho-button-comp",
-  "id": "tooltip:pho-button-comp:my-uuid",
-  "style": "--transition-delay-in: 700ms; --transition-delay-out: 300ms;",
+  "class": "wrapper relative",
+  "cy": "tooltip:pho-tooltip-comp",
+  "id": "tooltip:pho-tooltip-comp:my-uuid",
 }
 `;
 
 exports[`unit.vue.components.ui.PhoTooltip On mouse leave Hides the tooltip 1`] = `
 <div
   class="wrapper relative"
+  cy="tooltip:pho-tooltip-comp"
+  id="tooltip:pho-tooltip-comp:my-uuid"
 >
   <div
-    class="inline-block"
+    class="inline-block w-full"
   >
     
     

--- a/tests/unit/vue/components/ui/forms/PhoTextField.test.ts
+++ b/tests/unit/vue/components/ui/forms/PhoTextField.test.ts
@@ -16,6 +16,8 @@ const getComponent = <T>(props: T, attrs: Record<string, string> | {} = {}) => {
 
 describe('unit.vue.components.ui.forms.PhoTextField', () => {
 
+  beforeEach(() => jest.useFakeTimers());
+
   it('Mounts', () => {
     const wrapper = getComponent({});
     expect(wrapper.element).toMatchSnapshot();
@@ -57,5 +59,22 @@ describe('unit.vue.components.ui.forms.PhoTextField', () => {
         expect(wrapper.element).toMatchSnapshot();
       });
     });
+
+  describe('Renders the help', () => {
+    it('Switched off', () => {
+      const wrapper = getComponent({ help: 'Some Help' });
+      const help = wrapper.get('[cy="tooltip:pho-text-field-comp"]');
+      expect(help.element).toMatchSnapshot();
+    });
+
+    it('Switched on', async () => {
+      const wrapper = getComponent({ help: 'Some Help' });
+      const help = wrapper.get('[cy="tooltip:pho-text-field-comp"]');
+      await help.trigger('mouseenter');
+      await jest.runAllTimers();
+      expect(help.element).toMatchSnapshot();
+    });
+
+  });
 
 });

--- a/tests/unit/vue/components/ui/forms/__snapshots__/PhoTextField.test.ts.snap
+++ b/tests/unit/vue/components/ui/forms/__snapshots__/PhoTextField.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`unit.vue.components.ui.forms.PhoTextField Mounts 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -12,12 +12,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Mounts 1`] = `
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'date' field 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -27,12 +28,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'date' field 1`] = 
     name="pho-text-field-comp"
     type="date"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'number' field 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -42,12 +44,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'number' field 1`] 
     name="pho-text-field-comp"
     type="number"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'password' field 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -57,12 +60,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'password' field 1`
     name="pho-text-field-comp"
     type="password"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'text' field 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -72,12 +76,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders a 'text' field 1`] = 
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders a disabled field 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <!--v-if-->
   <input
@@ -88,12 +93,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders a disabled field 1`] 
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over the input 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
   min="1900"
 >
   <!--v-if-->
@@ -105,12 +111,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over t
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over the input 2`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
   max="2100"
 >
   <!--v-if-->
@@ -122,12 +129,13 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over t
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over the input 3`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
   max="2100"
   min="1900"
 >
@@ -141,12 +149,94 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders the extra attr over t
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
+</div>
+`;
+
+exports[`unit.vue.components.ui.forms.PhoTextField Renders the help Switched off 1`] = `
+<div
+  class="wrapper relative"
+  cy="tooltip:pho-text-field-comp"
+  id="tooltip:pho-text-field-comp:65441ec3-a9fa-4e8c-b1e5-79d7d001e634"
+>
+  <div
+    class="inline-block w-full"
+  >
+    
+    <svg
+      aria-hidden="true"
+      class="svg-inline--fa fa-info-circle fa-w-16"
+      data-icon="info-circle"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        class=""
+        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        fill="currentColor"
+      />
+    </svg>
+    
+  </div>
+  <transition-stub>
+    <!--v-if-->
+  </transition-stub>
+</div>
+`;
+
+exports[`unit.vue.components.ui.forms.PhoTextField Renders the help Switched on 1`] = `
+<div
+  class="wrapper relative"
+  cy="tooltip:pho-text-field-comp"
+  id="tooltip:pho-text-field-comp:65441ec3-a9fa-4e8c-b1e5-79d7d001e634"
+>
+  <div
+    class="inline-block w-full"
+  >
+    
+    <svg
+      aria-hidden="true"
+      class="svg-inline--fa fa-info-circle fa-w-16"
+      data-icon="info-circle"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        class=""
+        d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+        fill="currentColor"
+      />
+    </svg>
+    
+  </div>
+  <transition-stub>
+    <div
+      ci="tooltip:pho-text-field-comp:tooltip"
+      class="tooltip absolute bg-gray-800 text-white rounded-sm text-center px-2 py-1 top"
+      id="tooltip:pho-text-field-comp:65441ec3-a9fa-4e8c-b1e5-79d7d001e634:tooltip"
+      style="--transition-delay-in: 700ms; --transition-delay-out: 300ms;"
+    >
+      
+      <div
+        class="text-xs tracking-wide"
+      >
+        Some Help
+      </div>
+      
+    </div>
+  </transition-stub>
 </div>
 `;
 
 exports[`unit.vue.components.ui.forms.PhoTextField Renders the label 1`] = `
 <div
-  class="pho-field-wrapper"
+  class="pho-field-wrapper w-full relative"
 >
   <label
     class="pho-label"
@@ -161,6 +251,7 @@ exports[`unit.vue.components.ui.forms.PhoTextField Renders the label 1`] = `
     name="pho-text-field-comp"
     type="text"
   />
+  <!--v-if-->
 </div>
 `;
 


### PR DESCRIPTION
Tooltips should be clickable because mobile users can't over. Click overrides the mouseenter event. Transition is now triggered with a setTimeout that keeps its own reference. I know setTimeout is way worse than a delayed transition, but we need instant feedback for direct clicks. Any delay feels sluggish and poor.

Additionally, PhoTextField now can pass a `help` prop that will automatically render a tooltip on the right side of the label. Identifiers are generated by the PhoTextField component.